### PR TITLE
crawl for geom_alt prop updates

### DIFF
--- a/data/421/166/797/421166797.geojson
+++ b/data/421/166/797/421166797.geojson
@@ -52,6 +52,9 @@
     },
     "wof:country":"GE",
     "wof:created":1459008703,
+    "wof:geom_alt":[
+        "naturalearth-display-terrestrial-zoom6"
+    ],
     "wof:geomhash":"e8b768dacc1c34f7c02d4fddde3954b4",
     "wof:hierarchy":[
         {
@@ -60,7 +63,7 @@
         }
     ],
     "wof:id":421166797,
-    "wof:lastmodified":1527716101,
+    "wof:lastmodified":1582343850,
     "wof:name":"Georgia",
     "wof:parent_id":102191569,
     "wof:placetype":"country",

--- a/data/421/190/605/421190605.geojson
+++ b/data/421/190/605/421190605.geojson
@@ -398,8 +398,9 @@
     "qs:woe_id":1963698,
     "src:geom":"whosonfirst",
     "src:geom_alt":[
-        "quattroshapes_pg",
-        "quattroshapes"
+        "naturalearth",
+        "quattroshapes",
+        "quattroshapes_pg"
     ],
     "src:population":"wk",
     "wd:latitude":42.25,
@@ -425,6 +426,11 @@
     },
     "wof:country":"GE",
     "wof:created":1459009663,
+    "wof:geom_alt":[
+        "naturalearth",
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"df64089574128f06599fe5939e725a97",
     "wof:hierarchy":[
         {
@@ -436,7 +442,7 @@
         }
     ],
     "wof:id":421190605,
-    "wof:lastmodified":1566637209,
+    "wof:lastmodified":1582343850,
     "wof:name":"K'ut'aisi",
     "wof:parent_id":1108691319,
     "wof:placetype":"locality",

--- a/data/421/203/121/421203121.geojson
+++ b/data/421/203/121/421203121.geojson
@@ -365,6 +365,9 @@
     },
     "wof:country":"GE",
     "wof:created":1459010141,
+    "wof:geom_alt":[
+        "naturalearth"
+    ],
     "wof:geomhash":"6f72ced689d537e4951fc9c3c86b3b47",
     "wof:hierarchy":[
         {
@@ -376,7 +379,7 @@
         }
     ],
     "wof:id":421203121,
-    "wof:lastmodified":1566637199,
+    "wof:lastmodified":1582343850,
     "wof:name":"Rustavi",
     "wof:parent_id":1108691281,
     "wof:placetype":"locality",

--- a/data/856/331/63/85633163.geojson
+++ b/data/856/331/63/85633163.geojson
@@ -1151,8 +1151,9 @@
     "qs:source":"EuroGlobalMap",
     "src:geom":"whosonfirst",
     "src:geom_alt":[
-        "quattroshapes",
-        "meso"
+        "naturalearth",
+        "meso",
+        "quattroshapes"
     ],
     "src:geom_via":"quattroshapes",
     "src:lbl_centroid":"mapshaper",
@@ -1201,6 +1202,11 @@
     },
     "wof:country":"GE",
     "wof:country_alpha3":"GEO",
+    "wof:geom_alt":[
+        "naturalearth",
+        "meso",
+        "quattroshapes"
+    ],
     "wof:geomhash":"126a90f96ed58b79d01691c5944bb967",
     "wof:hierarchy":[
         {
@@ -1217,7 +1223,7 @@
         "abk",
         "oss"
     ],
-    "wof:lastmodified":1566636842,
+    "wof:lastmodified":1582343845,
     "wof:name":"Georgia",
     "wof:parent_id":102191569,
     "wof:placetype":"country",

--- a/data/890/443/227/890443227.geojson
+++ b/data/890/443/227/890443227.geojson
@@ -714,6 +714,10 @@
     ],
     "wof:country":"GE",
     "wof:created":1469052414,
+    "wof:geom_alt":[
+        "unknown",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"646787f299203547cea77dc7da27e020",
     "wof:hierarchy":[
         {
@@ -725,7 +729,7 @@
         }
     ],
     "wof:id":890443227,
-    "wof:lastmodified":1566637218,
+    "wof:lastmodified":1582343850,
     "wof:name":"Tbilisi",
     "wof:parent_id":1108691371,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.