### PR TITLE
ge concordances, placetype local, and more

### DIFF
--- a/data/110/869/123/7/1108691237.geojson
+++ b/data/110/869/123/7/1108691237.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.027765,
-    "geom:area_square_m":254321890.357611,
+    "geom:area_square_m":254322155.219597,
     "geom:bbox":"42.050423,42.105999,42.352188,42.305202",
     "geom:latitude":42.203747,
     "geom:longitude":42.21581,
@@ -140,9 +140,10 @@
         "hasc:id":"GE.SZ.AS",
         "wd:id":"Q2513666"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GE",
     "wof:created":1474307851,
-    "wof:geomhash":"05a1c985e3855399e579406208b36079",
+    "wof:geomhash":"91b324ae3025e1b2275c7d7d52b69053",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -152,7 +153,7 @@
         }
     ],
     "wof:id":1108691237,
-    "wof:lastmodified":1690921407,
+    "wof:lastmodified":1695886293,
     "wof:name":"Abasha",
     "wof:parent_id":1108805935,
     "wof:placetype":"county",

--- a/data/110/869/123/9/1108691239.geojson
+++ b/data/110/869/123/9/1108691239.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.083872,
-    "geom:area_square_m":774185720.301804,
+    "geom:area_square_m":774186139.290543,
     "geom:bbox":"42.493076,41.578407,42.963383,41.834236",
     "geom:latitude":41.712061,
     "geom:longitude":42.717851,
@@ -145,9 +145,10 @@
         "hasc:id":"GE.SJ.AD",
         "wd:id":"Q2382197"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GE",
     "wof:created":1474307853,
-    "wof:geomhash":"c569d6607458f9823da9f5a6895fd893",
+    "wof:geomhash":"1b9a55056a597948e213deebae227a7f",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -157,7 +158,7 @@
         }
     ],
     "wof:id":1108691239,
-    "wof:lastmodified":1690921407,
+    "wof:lastmodified":1695886293,
     "wof:name":"Adigeni",
     "wof:parent_id":1108805953,
     "wof:placetype":"county",

--- a/data/110/869/124/1/1108691241.geojson
+++ b/data/110/869/124/1/1108691241.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.103583,
-    "geom:area_square_m":948252673.0947,
+    "geom:area_square_m":948252446.416892,
     "geom:bbox":"44.259342,42.019241,44.621704,42.520405",
     "geom:latitude":42.238925,
     "geom:longitude":44.441983,
@@ -142,9 +142,10 @@
         "hasc:id":"GE.MM.AG",
         "wd:id":"Q18586221"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GE",
     "wof:created":1474307855,
-    "wof:geomhash":"6f14a7e1c173c9298fcdeebc5968bf2f",
+    "wof:geomhash":"ad054fc7d0fe9c6dda052b7bf63527f8",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -154,7 +155,7 @@
         }
     ],
     "wof:id":1108691241,
-    "wof:lastmodified":1690921408,
+    "wof:lastmodified":1695886293,
     "wof:name":"Akhalgori",
     "wof:parent_id":1108805943,
     "wof:placetype":"county",

--- a/data/110/869/124/3/1108691243.geojson
+++ b/data/110/869/124/3/1108691243.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.135887,
-    "geom:area_square_m":1259810648.83155,
+    "geom:area_square_m":1259810859.02993,
     "geom:bbox":"43.143646,41.169235,43.724358,41.687267",
     "geom:latitude":41.429481,
     "geom:longitude":43.46001,
@@ -142,9 +142,10 @@
         "hasc:id":"GE.SJ.AK",
         "wd:id":"Q1851196"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GE",
     "wof:created":1474307856,
-    "wof:geomhash":"d3e0eae85cfcce0d81eea7dd779eb8c7",
+    "wof:geomhash":"d9f29438baca18323f4bb2b0a7ff1826",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -154,7 +155,7 @@
         }
     ],
     "wof:id":1108691243,
-    "wof:lastmodified":1690921409,
+    "wof:lastmodified":1695886293,
     "wof:name":"Akhalkalaki",
     "wof:parent_id":1108805953,
     "wof:placetype":"county",

--- a/data/110/869/124/5/1108691245.geojson
+++ b/data/110/869/124/5/1108691245.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.106598,
-    "geom:area_square_m":985139837.225209,
+    "geom:area_square_m":985140336.686334,
     "geom:bbox":"42.79414,41.424446,43.276154,41.832333",
     "geom:latitude":41.635079,
     "geom:longitude":43.017681,
@@ -151,9 +151,10 @@
         "hasc:id":"GE.SJ.AT",
         "wd:id":"Q2513568"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GE",
     "wof:created":1474307858,
-    "wof:geomhash":"a05d3f13b2165a024425439b297be374",
+    "wof:geomhash":"7ec4609faac4c22b2ab2845b80b58c41",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -163,7 +164,7 @@
         }
     ],
     "wof:id":1108691245,
-    "wof:lastmodified":1690921409,
+    "wof:lastmodified":1695886293,
     "wof:name":"Akhaltsikhe",
     "wof:parent_id":1108805953,
     "wof:placetype":"county",

--- a/data/110/869/124/7/1108691247.geojson
+++ b/data/110/869/124/7/1108691247.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.242899,
-    "geom:area_square_m":2223102002.371046,
+    "geom:area_square_m":2223102579.778941,
     "geom:bbox":"45.046131,41.873653,45.780636,42.565769",
     "geom:latitude":42.253593,
     "geom:longitude":45.373186,
@@ -154,9 +154,10 @@
         "hasc:id":"GE.KA.AM",
         "wd:id":"Q748753"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GE",
     "wof:created":1474307859,
-    "wof:geomhash":"fce28695dc5e2c769931153bbdd55226",
+    "wof:geomhash":"cfc9feaabf94524ce52c207b30cbf618",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -166,7 +167,7 @@
         }
     ],
     "wof:id":1108691247,
-    "wof:lastmodified":1690921408,
+    "wof:lastmodified":1695886293,
     "wof:name":"Akhmeta",
     "wof:parent_id":1108805939,
     "wof:placetype":"county",

--- a/data/110/869/124/9/1108691249.geojson
+++ b/data/110/869/124/9/1108691249.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.124705,
-    "geom:area_square_m":1135677253.817552,
+    "geom:area_square_m":1135677831.980478,
     "geom:bbox":"42.837715,42.362499,43.360088,42.823307",
     "geom:latitude":42.566254,
     "geom:longitude":43.121016,
@@ -148,9 +148,10 @@
         "hasc:id":"GE.RK.AL",
         "wd:id":"Q2464159"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GE",
     "wof:created":1474307861,
-    "wof:geomhash":"a670a9db54b357d0dcad56fc28c88e10",
+    "wof:geomhash":"b66a49b482505744b6412333fa791710",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -160,7 +161,7 @@
         }
     ],
     "wof:id":1108691249,
-    "wof:lastmodified":1690921407,
+    "wof:lastmodified":1695886293,
     "wof:name":"Ambrolauri",
     "wof:parent_id":1108805959,
     "wof:placetype":"county",

--- a/data/110/869/125/1/1108691251.geojson
+++ b/data/110/869/125/1/1108691251.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.092635,
-    "geom:area_square_m":857964745.702697,
+    "geom:area_square_m":857964628.081493,
     "geom:bbox":"42.965675,41.278412,43.442188,41.695938",
     "geom:latitude":41.49439,
     "geom:longitude":43.216695,
@@ -145,9 +145,10 @@
         "hasc:id":"GE.SJ.AZ",
         "wd:id":"Q2305733"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GE",
     "wof:created":1474307862,
-    "wof:geomhash":"839ea22f9a72428a91a3afe57194a448",
+    "wof:geomhash":"cb18b329ee33c8cfbc821c47dc211a00",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -157,7 +158,7 @@
         }
     ],
     "wof:id":1108691251,
-    "wof:lastmodified":1690921410,
+    "wof:lastmodified":1695886293,
     "wof:name":"Aspindza",
     "wof:parent_id":1108805953,
     "wof:placetype":"county",

--- a/data/110/869/125/5/1108691255.geojson
+++ b/data/110/869/125/5/1108691255.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.090824,
-    "geom:area_square_m":835040268.91216,
+    "geom:area_square_m":835040467.354845,
     "geom:bbox":"42.642963,41.804096,43.12619,42.195316",
     "geom:latitude":41.966069,
     "geom:longitude":42.87971,
@@ -67,9 +67,10 @@
     "wof:concordances":{
         "hasc:id":"GE.IM.BG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GE",
     "wof:created":1474307864,
-    "wof:geomhash":"12dead84619a2572253f6b8ccb997511",
+    "wof:geomhash":"420bd4e2dcc3afbd605911ec7b4b0b21",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1108691255,
-    "wof:lastmodified":1627522152,
+    "wof:lastmodified":1695886621,
     "wof:name":"Bagdati",
     "wof:parent_id":1108805937,
     "wof:placetype":"county",

--- a/data/110/869/125/7/1108691257.geojson
+++ b/data/110/869/125/7/1108691257.geojson
@@ -54,6 +54,7 @@
     "wof:concordances":{
         "hasc:id":"GE.AJ.BT"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GE",
     "wof:created":1474307865,
     "wof:geomhash":"5fde8bbe66ae7249232fae0a1ef6a635",
@@ -66,7 +67,7 @@
         }
     ],
     "wof:id":1108691257,
-    "wof:lastmodified":1694498070,
+    "wof:lastmodified":1695886255,
     "wof:name":"Batumi City",
     "wof:parent_id":1108805947,
     "wof:placetype":"county",

--- a/data/110/869/125/9/1108691259.geojson
+++ b/data/110/869/125/9/1108691259.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.084085,
-    "geom:area_square_m":780247809.250822,
+    "geom:area_square_m":780247915.213061,
     "geom:bbox":"44.248947,41.178341,44.788754,41.498219",
     "geom:latitude":41.37179,
     "geom:longitude":44.51011,
@@ -139,9 +139,10 @@
         "hasc:id":"GE.KK.BL",
         "wd:id":"Q2513580"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GE",
     "wof:created":1474307867,
-    "wof:geomhash":"0d81d84bc57cacdec7a20a0e1c8aad4c",
+    "wof:geomhash":"60611afec44a05bd3b5f47f51a59a5d4",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -151,7 +152,7 @@
         }
     ],
     "wof:id":1108691259,
-    "wof:lastmodified":1690921410,
+    "wof:lastmodified":1695886293,
     "wof:name":"Bolnisi",
     "wof:parent_id":1108805951,
     "wof:placetype":"county",

--- a/data/110/869/126/1/1108691261.geojson
+++ b/data/110/869/126/1/1108691261.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.129386,
-    "geom:area_square_m":1193219337.941574,
+    "geom:area_square_m":1193219337.941609,
     "geom:bbox":"43.1261901855,41.5914802551,43.8938789368,41.9391021729",
     "geom:latitude":41.77088,
     "geom:longitude":43.488967,
@@ -186,9 +186,10 @@
     "wof:concordances":{
         "hasc:id":"GE.SJ.BR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GE",
     "wof:created":1474307868,
-    "wof:geomhash":"e4d6209922ccb08fa22f569211e628ff",
+    "wof:geomhash":"ba28bc04182ea471d2a027b3e232d474",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -198,7 +199,7 @@
         }
     ],
     "wof:id":1108691261,
-    "wof:lastmodified":1566637100,
+    "wof:lastmodified":1695886291,
     "wof:name":"Borjomi",
     "wof:parent_id":1108805953,
     "wof:placetype":"county",

--- a/data/110/869/126/3/1108691263.geojson
+++ b/data/110/869/126/3/1108691263.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.059195,
-    "geom:area_square_m":541615382.097797,
+    "geom:area_square_m":541615370.914454,
     "geom:bbox":"43.108898,42.120834,43.453815,42.433937",
     "geom:latitude":42.272484,
     "geom:longitude":43.26847,
@@ -137,9 +137,10 @@
         "hasc:id":"GE.IM.CT",
         "wd:id":"Q269506"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GE",
     "wof:created":1474307869,
-    "wof:geomhash":"4c7812bb5f844b47309eab7d45d09cfd",
+    "wof:geomhash":"ca47d6dba974cf0e74b8cb88cd1c263a",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -149,7 +150,7 @@
         }
     ],
     "wof:id":1108691263,
-    "wof:lastmodified":1690921397,
+    "wof:lastmodified":1695886291,
     "wof:name":"Chiatura",
     "wof:parent_id":1108805937,
     "wof:placetype":"county",

--- a/data/110/869/126/5/1108691265.geojson
+++ b/data/110/869/126/5/1108691265.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.068214,
-    "geom:area_square_m":620648891.692094,
+    "geom:area_square_m":620648863.342477,
     "geom:bbox":"42.011314,42.39711,42.434826,42.836288",
     "geom:latitude":42.623789,
     "geom:longitude":42.232171,
@@ -67,9 +67,10 @@
     "wof:concordances":{
         "hasc:id":"GE.SZ.CQ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GE",
     "wof:created":1474307871,
-    "wof:geomhash":"7664936eb17f5ab45c6fee88ba884d21",
+    "wof:geomhash":"9e96b1a903aa03f5e6012bd457f431e7",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1108691265,
-    "wof:lastmodified":1627522152,
+    "wof:lastmodified":1695886621,
     "wof:name":"Chkhorotsku",
     "wof:parent_id":1108805935,
     "wof:placetype":"county",

--- a/data/110/869/126/7/1108691267.geojson
+++ b/data/110/869/126/7/1108691267.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.088856,
-    "geom:area_square_m":817453397.310988,
+    "geom:area_square_m":817453954.926032,
     "geom:bbox":"42.126961,41.788834,42.668873,42.080322",
     "geom:latitude":41.926036,
     "geom:longitude":42.393751,
@@ -143,9 +143,10 @@
         "hasc:id":"GE.GU.CK",
         "wd:id":"Q2466860"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GE",
     "wof:created":1474307872,
-    "wof:geomhash":"067cd1e5fb4617cc5ec15df7b9835ba7",
+    "wof:geomhash":"a115cd71c40ea1797b60c61e876e4c4c",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -155,7 +156,7 @@
         }
     ],
     "wof:id":1108691267,
-    "wof:lastmodified":1690921397,
+    "wof:lastmodified":1695886291,
     "wof:name":"Chokhatauri",
     "wof:parent_id":1108805955,
     "wof:placetype":"county",

--- a/data/110/869/126/9/1108691269.geojson
+++ b/data/110/869/126/9/1108691269.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.26948,
-    "geom:area_square_m":2503151198.688692,
+    "geom:area_square_m":2503151021.621813,
     "geom:bbox":"45.748657,41.044666,46.733837,41.572384",
     "geom:latitude":41.30492,
     "geom:longitude":46.245767,
@@ -67,9 +67,10 @@
     "wof:concordances":{
         "hasc:id":"GE.KA.DD"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GE",
     "wof:created":1474307874,
-    "wof:geomhash":"312a1ed56185fbd681e20e745336712a",
+    "wof:geomhash":"4e9e19ea3d2c3e768f37c6cdc12e0626",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1108691269,
-    "wof:lastmodified":1627522152,
+    "wof:lastmodified":1695886621,
     "wof:name":"Dedoplitskaro",
     "wof:parent_id":1108805939,
     "wof:placetype":"county",

--- a/data/110/869/127/3/1108691273.geojson
+++ b/data/110/869/127/3/1108691273.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.127296,
-    "geom:area_square_m":1181700471.911409,
+    "geom:area_square_m":1181700705.152247,
     "geom:bbox":"43.89045,41.164169,44.437691,41.548832",
     "geom:latitude":41.344987,
     "geom:longitude":44.134711,
@@ -134,9 +134,10 @@
         "hasc:id":"GE.KK.DM",
         "wd:id":"Q681371"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GE",
     "wof:created":1474307875,
-    "wof:geomhash":"d43aaf90a3709c27ffd5d2f17f9b2b02",
+    "wof:geomhash":"1a530ccde7ef61e442cf121bcc06f13b",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -146,7 +147,7 @@
         }
     ],
     "wof:id":1108691273,
-    "wof:lastmodified":1690921396,
+    "wof:lastmodified":1695886291,
     "wof:name":"Dmanisi",
     "wof:parent_id":1108805951,
     "wof:placetype":"county",

--- a/data/110/869/127/5/1108691275.geojson
+++ b/data/110/869/127/5/1108691275.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.326379,
-    "geom:area_square_m":2981578174.61128,
+    "geom:area_square_m":2981578159.896466,
     "geom:bbox":"44.466774,41.930035,45.310886,42.74818",
     "geom:latitude":42.370901,
     "geom:longitude":44.865138,
@@ -149,9 +149,10 @@
         "hasc:id":"GE.MM.DU",
         "wd:id":"Q2474310"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GE",
     "wof:created":1474307876,
-    "wof:geomhash":"a56b9344f596480223707ffb61548abe",
+    "wof:geomhash":"b95ed63ba5ad27802b690999c9a47ac5",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -161,7 +162,7 @@
         }
     ],
     "wof:id":1108691275,
-    "wof:lastmodified":1690921396,
+    "wof:lastmodified":1695886291,
     "wof:name":"Dusheti",
     "wof:parent_id":1108805943,
     "wof:placetype":"county",

--- a/data/110/869/127/7/1108691277.geojson
+++ b/data/110/869/127/7/1108691277.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.113618,
-    "geom:area_square_m":1020562363.194103,
+    "geom:area_square_m":1020562363.194087,
     "geom:bbox":"40.0023574829,43.1456298828,40.4977226257,43.5840034485",
     "geom:latitude":43.412193,
     "geom:longitude":40.266547,
@@ -271,9 +271,10 @@
     "wof:concordances":{
         "hasc:id":"GE.AB.GG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GE",
     "wof:created":1474307878,
-    "wof:geomhash":"6d1eba7a5016aa513ac42e7d365ad0c1",
+    "wof:geomhash":"4efcff57d7a6fee5876424e4e6adb784",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -283,7 +284,7 @@
         }
     ],
     "wof:id":1108691277,
-    "wof:lastmodified":1566637099,
+    "wof:lastmodified":1695886291,
     "wof:name":"Gagra",
     "wof:parent_id":1108805957,
     "wof:placetype":"county",

--- a/data/110/869/127/9/1108691279.geojson
+++ b/data/110/869/127/9/1108691279.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.104287,
-    "geom:area_square_m":948745650.224571,
+    "geom:area_square_m":948745477.863351,
     "geom:bbox":"41.485909,42.41777,41.947876,42.82906",
     "geom:latitude":42.630966,
     "geom:longitude":41.711341,
@@ -82,9 +82,10 @@
     "wof:concordances":{
         "hasc:id":"GE.AB.GL"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GE",
     "wof:created":1474307879,
-    "wof:geomhash":"d5fa66f7046075d8223d6ddf99a5b482",
+    "wof:geomhash":"8a4b565e65a7b9fcce91e54bbb48f253",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -94,7 +95,7 @@
         }
     ],
     "wof:id":1108691279,
-    "wof:lastmodified":1627522152,
+    "wof:lastmodified":1695886621,
     "wof:name":"Gali",
     "wof:parent_id":1108805957,
     "wof:placetype":"county",

--- a/data/110/869/128/1/1108691281.geojson
+++ b/data/110/869/128/1/1108691281.geojson
@@ -121,6 +121,7 @@
         "hasc:id":"GE.KK.GD",
         "wd:id":"Q2512996"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GE",
     "wof:created":1474307881,
     "wof:geomhash":"1a4a9173620d06854e506fcc58bc0d1a",
@@ -133,7 +134,7 @@
         }
     ],
     "wof:id":1108691281,
-    "wof:lastmodified":1694497838,
+    "wof:lastmodified":1695886291,
     "wof:name":"Gardabani",
     "wof:parent_id":1108805951,
     "wof:placetype":"county",

--- a/data/110/869/128/3/1108691283.geojson
+++ b/data/110/869/128/3/1108691283.geojson
@@ -134,6 +134,7 @@
         "hasc:id":"GE.SD.GR",
         "wd:id":"Q1417170"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GE",
     "wof:created":1474307882,
     "wof:geomhash":"da290741ab30a2b67e54a4aa340ce388",
@@ -146,7 +147,7 @@
         }
     ],
     "wof:id":1108691283,
-    "wof:lastmodified":1694497838,
+    "wof:lastmodified":1695886291,
     "wof:name":"Gori",
     "wof:parent_id":1108805941,
     "wof:placetype":"county",

--- a/data/110/869/128/5/1108691285.geojson
+++ b/data/110/869/128/5/1108691285.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.15908,
-    "geom:area_square_m":1431921588.150766,
+    "geom:area_square_m":1431921588.150915,
     "geom:bbox":"40.3616294861,43.0614395142,40.9026298523,43.5530929565",
     "geom:latitude":43.284893,
     "geom:longitude":40.621946,
@@ -194,9 +194,10 @@
     "wof:concordances":{
         "hasc:id":"GE.AB.GT"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GE",
     "wof:created":1474307884,
-    "wof:geomhash":"f384c9d045c5c8252dcd41d1c5fe1a82",
+    "wof:geomhash":"73c4ac76220020d0cb7b110baf69df03",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -206,7 +207,7 @@
         }
     ],
     "wof:id":1108691285,
-    "wof:lastmodified":1566637101,
+    "wof:lastmodified":1695886291,
     "wof:name":"Gudauta",
     "wof:parent_id":1108805957,
     "wof:placetype":"county",

--- a/data/110/869/128/7/1108691287.geojson
+++ b/data/110/869/128/7/1108691287.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.204933,
-    "geom:area_square_m":1849524617.860536,
+    "geom:area_square_m":1849524617.860641,
     "geom:bbox":"41.0673980713,42.8018341064,42.1509628296,43.3649291992",
     "geom:latitude":43.124179,
     "geom:longitude":41.482345,
@@ -136,9 +136,10 @@
     "wof:concordances":{
         "hasc:id":"GE.AB.GP"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GE",
     "wof:created":1474307885,
-    "wof:geomhash":"1037ddbee3f2092d8c061252b8d2b992",
+    "wof:geomhash":"4f29d0bbc84e491e290a7a29e614b890",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -148,7 +149,7 @@
         }
     ],
     "wof:id":1108691287,
-    "wof:lastmodified":1566637100,
+    "wof:lastmodified":1695886291,
     "wof:name":"Gulripshi",
     "wof:parent_id":1108805957,
     "wof:placetype":"county",

--- a/data/110/869/129/1/1108691291.geojson
+++ b/data/110/869/129/1/1108691291.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.091384,
-    "geom:area_square_m":843352960.124971,
+    "geom:area_square_m":843352746.283038,
     "geom:bbox":"45.520592,41.531876,45.979099,41.898666",
     "geom:latitude":41.725096,
     "geom:longitude":45.739201,
@@ -137,9 +137,10 @@
         "hasc:id":"GE.KA.GJ",
         "wd:id":"Q1560942"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GE",
     "wof:created":1474307887,
-    "wof:geomhash":"7a458de10bfb8a457244d523ed38c16e",
+    "wof:geomhash":"63b6f963b819ed9357f2fc1096002f80",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -149,7 +150,7 @@
         }
     ],
     "wof:id":1108691291,
-    "wof:lastmodified":1690921394,
+    "wof:lastmodified":1695886291,
     "wof:name":"Gurjaani",
     "wof:parent_id":1108805939,
     "wof:placetype":"county",

--- a/data/110/869/129/3/1108691293.geojson
+++ b/data/110/869/129/3/1108691293.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.104735,
-    "geom:area_square_m":955231840.376033,
+    "geom:area_square_m":955232154.787412,
     "geom:bbox":"43.585419,42.318718,44.348026,42.627548",
     "geom:latitude":42.473248,
     "geom:longitude":44.013563,
@@ -138,9 +138,10 @@
         "hasc:id":"GE.SD.JV",
         "wd:id":"Q893278"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GE",
     "wof:created":1474307888,
-    "wof:geomhash":"c56f73689a5f57dea64fb5e513562df9",
+    "wof:geomhash":"c80ff39019862403c77dc5353f016aa0",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -150,7 +151,7 @@
         }
     ],
     "wof:id":1108691293,
-    "wof:lastmodified":1690921395,
+    "wof:lastmodified":1695886291,
     "wof:name":"Java",
     "wof:parent_id":1108805941,
     "wof:placetype":"county",

--- a/data/110/869/129/5/1108691295.geojson
+++ b/data/110/869/129/5/1108691295.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.118888,
-    "geom:area_square_m":1091284475.441449,
+    "geom:area_square_m":1091284374.863907,
     "geom:bbox":"43.61491,41.784626,44.057518,42.344681",
     "geom:latitude":42.069159,
     "geom:longitude":43.807119,
@@ -133,9 +133,10 @@
         "hasc:id":"GE.SD.KR",
         "wd:id":"Q1756629"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GE",
     "wof:created":1474307890,
-    "wof:geomhash":"360c3de05a5c96670aca40158c8dd9bf",
+    "wof:geomhash":"2f6c0adeb6a091a9419125e15612e294",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -145,7 +146,7 @@
         }
     ],
     "wof:id":1108691295,
-    "wof:lastmodified":1690921395,
+    "wof:lastmodified":1695886291,
     "wof:name":"Kareli",
     "wof:parent_id":1108805941,
     "wof:placetype":"county",

--- a/data/110/869/129/7/1108691297.geojson
+++ b/data/110/869/129/7/1108691297.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.087415,
-    "geom:area_square_m":804754894.400279,
+    "geom:area_square_m":804754307.577587,
     "geom:bbox":"44.152031,41.730381,44.573429,42.053501",
     "geom:latitude":41.882219,
     "geom:longitude":44.36995,
@@ -142,9 +142,10 @@
         "hasc:id":"GE.SD.KP",
         "wd:id":"Q1518087"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GE",
     "wof:created":1474307891,
-    "wof:geomhash":"d5abfa5a23909da791ef284717e13e2d",
+    "wof:geomhash":"cde05f872529673ca98ae29766f776dd",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -154,7 +155,7 @@
         }
     ],
     "wof:id":1108691297,
-    "wof:lastmodified":1690921394,
+    "wof:lastmodified":1695886291,
     "wof:name":"Kaspi",
     "wof:parent_id":1108805941,
     "wof:placetype":"county",

--- a/data/110/869/129/9/1108691299.geojson
+++ b/data/110/869/129/9/1108691299.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.120413,
-    "geom:area_square_m":1095853810.028864,
+    "geom:area_square_m":1095854325.416418,
     "geom:bbox":"44.222141,42.426712,44.853363,42.761959",
     "geom:latitude":42.608218,
     "geom:longitude":44.530838,
@@ -146,9 +146,10 @@
         "hasc:id":"GE.MM.QZ",
         "wd:id":"Q2475628"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GE",
     "wof:created":1474307892,
-    "wof:geomhash":"593195a70a25205b857511e13594628e",
+    "wof:geomhash":"eac7bc66394b0bb6b9fb854aa6149a7b",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -158,7 +159,7 @@
         }
     ],
     "wof:id":1108691299,
-    "wof:lastmodified":1690921394,
+    "wof:lastmodified":1695886290,
     "wof:name":"Kazbegi",
     "wof:parent_id":1108805943,
     "wof:placetype":"county",

--- a/data/110/869/130/1/1108691301.geojson
+++ b/data/110/869/130/1/1108691301.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.04717,
-    "geom:area_square_m":436238027.253582,
+    "geom:area_square_m":436237551.01947,
     "geom:bbox":"41.754894,41.492966,42.126358,41.698936",
     "geom:latitude":41.588752,
     "geom:longitude":41.969494,
@@ -136,9 +136,10 @@
         "hasc:id":"GE.AJ.KD",
         "wd:id":"Q1911993"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GE",
     "wof:created":1474307894,
-    "wof:geomhash":"c52bb6db07e0562ffab6d0ea2c17c05c",
+    "wof:geomhash":"0c845f0a6ef72f852f74eeae5b5e5f6b",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -148,7 +149,7 @@
         }
     ],
     "wof:id":1108691301,
-    "wof:lastmodified":1690921405,
+    "wof:lastmodified":1695886293,
     "wof:name":"Keda",
     "wof:parent_id":1108805947,
     "wof:placetype":"county",

--- a/data/110/869/130/3/1108691303.geojson
+++ b/data/110/869/130/3/1108691303.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.098579,
-    "geom:area_square_m":905853022.497044,
+    "geom:area_square_m":905853276.519,
     "geom:bbox":"42.999405,41.828495,43.505634,42.155926",
     "geom:latitude":42.000122,
     "geom:longitude":43.265691,
@@ -145,9 +145,10 @@
         "hasc:id":"GE.IM.KG",
         "wd:id":"Q2513642"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GE",
     "wof:created":1474307895,
-    "wof:geomhash":"92dc002ef1171710f611cde595cb64d2",
+    "wof:geomhash":"b1427f984060dccb4028f3db908f7eb3",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -157,7 +158,7 @@
         }
     ],
     "wof:id":1108691303,
-    "wof:lastmodified":1690921406,
+    "wof:lastmodified":1695886293,
     "wof:name":"Kharagauli",
     "wof:parent_id":1108805937,
     "wof:placetype":"county",

--- a/data/110/869/130/5/1108691305.geojson
+++ b/data/110/869/130/5/1108691305.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.063088,
-    "geom:area_square_m":579632839.955067,
+    "geom:area_square_m":579633156.057946,
     "geom:bbox":"43.422741,41.835705,43.769302,42.203228",
     "geom:latitude":42.009822,
     "geom:longitude":43.616422,
@@ -137,9 +137,10 @@
         "hasc:id":"GE.SD.KS",
         "wd:id":"Q1790675"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GE",
     "wof:created":1474307897,
-    "wof:geomhash":"cfedb9343ccbcd17695544cff7a3cfd0",
+    "wof:geomhash":"58ce7ee613e05846c8a3a4189e441d23",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -149,7 +150,7 @@
         }
     ],
     "wof:id":1108691305,
-    "wof:lastmodified":1690921406,
+    "wof:lastmodified":1695886293,
     "wof:name":"Khashuri",
     "wof:parent_id":1108805941,
     "wof:placetype":"county",

--- a/data/110/869/130/9/1108691309.geojson
+++ b/data/110/869/130/9/1108691309.geojson
@@ -100,6 +100,7 @@
     "wof:concordances":{
         "hasc:id":"GE.AJ.BT"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GE",
     "wof:created":1474307898,
     "wof:geomhash":"ff4c60a4317304ff7e4ec9218162af5a",
@@ -112,7 +113,7 @@
         }
     ],
     "wof:id":1108691309,
-    "wof:lastmodified":1694497838,
+    "wof:lastmodified":1695886292,
     "wof:name":"Khelvachauri",
     "wof:parent_id":1108805947,
     "wof:placetype":"county",

--- a/data/110/869/131/1/1108691311.geojson
+++ b/data/110/869/131/1/1108691311.geojson
@@ -124,6 +124,7 @@
         "hasc:id":"GE.SZ.KH",
         "wd:id":"Q2475615"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GE",
     "wof:created":1474307899,
     "wof:geomhash":"98e440d34ea77045ba72fb6d1700220d",
@@ -136,7 +137,7 @@
         }
     ],
     "wof:id":1108691311,
-    "wof:lastmodified":1694497838,
+    "wof:lastmodified":1695886291,
     "wof:name":"Khobi",
     "wof:parent_id":1108805935,
     "wof:placetype":"county",

--- a/data/110/869/131/3/1108691313.geojson
+++ b/data/110/869/131/3/1108691313.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.045668,
-    "geom:area_square_m":417077113.880447,
+    "geom:area_square_m":417077492.636161,
     "geom:bbox":"42.3232,42.225338,42.640057,42.561111",
     "geom:latitude":42.387778,
     "geom:longitude":42.495975,
@@ -133,9 +133,10 @@
         "hasc:id":"GE.IM.KN",
         "wd:id":"Q2513080"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GE",
     "wof:created":1474307901,
-    "wof:geomhash":"194cdee6712a9b7e53eb6035631b1d5f",
+    "wof:geomhash":"216f1c3be9135764d4dd1a814420dc30",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -145,7 +146,7 @@
         }
     ],
     "wof:id":1108691313,
-    "wof:lastmodified":1690921399,
+    "wof:lastmodified":1695886292,
     "wof:name":"Khoni",
     "wof:parent_id":1108805937,
     "wof:placetype":"county",

--- a/data/110/869/131/5/1108691315.geojson
+++ b/data/110/869/131/5/1108691315.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.07618,
-    "geom:area_square_m":703881638.279942,
+    "geom:area_square_m":703880858.187835,
     "geom:bbox":"42.252834,41.443996,42.602123,41.8409",
     "geom:latitude":41.648788,
     "geom:longitude":42.42404,
@@ -137,9 +137,10 @@
         "hasc:id":"GE.AJ.KL",
         "wd:id":"Q1252978"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GE",
     "wof:created":1474307902,
-    "wof:geomhash":"14bfe8d205aa5471e6b6d98d854fad56",
+    "wof:geomhash":"53272718032e1cdad9fdc3db9099e715",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -149,7 +150,7 @@
         }
     ],
     "wof:id":1108691315,
-    "wof:lastmodified":1690921400,
+    "wof:lastmodified":1695886292,
     "wof:name":"Khulo",
     "wof:parent_id":1108805947,
     "wof:placetype":"county",

--- a/data/110/869/131/7/1108691317.geojson
+++ b/data/110/869/131/7/1108691317.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.080015,
-    "geom:area_square_m":738041010.332989,
+    "geom:area_square_m":738041421.940456,
     "geom:bbox":"41.707737,41.607265,42.219452,41.899086",
     "geom:latitude":41.759198,
     "geom:longitude":41.925839,
@@ -140,9 +140,10 @@
         "hasc:id":"GE.AJ.KB",
         "wd:id":"Q991409"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GE",
     "wof:created":1474307904,
-    "wof:geomhash":"e080d0db1478aae493e02b9970f0698c",
+    "wof:geomhash":"959bee13e3b7738b2f8fd4858b83808f",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -152,7 +153,7 @@
         }
     ],
     "wof:id":1108691317,
-    "wof:lastmodified":1690921398,
+    "wof:lastmodified":1695886292,
     "wof:name":"Kobuleti",
     "wof:parent_id":1108805947,
     "wof:placetype":"county",

--- a/data/110/869/131/9/1108691319.geojson
+++ b/data/110/869/131/9/1108691319.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.003101,
-    "geom:area_square_m":28381982.009132,
+    "geom:area_square_m":28381982.009135,
     "geom:bbox":"42.661037,42.219509,42.736122,42.292564",
     "geom:latitude":42.258282,
     "geom:longitude":42.696259,
@@ -285,12 +285,13 @@
     "wof:concordances":{
         "hasc:id":"GE.IM.KT"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:coterminous":[
         421190605
     ],
     "wof:country":"GE",
     "wof:created":1474307905,
-    "wof:geomhash":"8df9f0fececee8b81cf98aa0c9800ccb",
+    "wof:geomhash":"f96bcd464b629bc0e1929f07a3276830",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -300,7 +301,7 @@
         }
     ],
     "wof:id":1108691319,
-    "wof:lastmodified":1608054816,
+    "wof:lastmodified":1695886457,
     "wof:name":"Kutaisi",
     "wof:parent_id":1108805937,
     "wof:placetype":"county",

--- a/data/110/869/132/1/1108691321.geojson
+++ b/data/110/869/132/1/1108691321.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.102161,
-    "geom:area_square_m":939303923.548049,
+    "geom:area_square_m":939303510.697601,
     "geom:bbox":"45.557659,41.796371,46.121552,42.123283",
     "geom:latitude":41.963792,
     "geom:longitude":45.857764,
@@ -139,9 +139,10 @@
         "hasc:id":"GE.KA.QV",
         "wd:id":"Q1789499"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GE",
     "wof:created":1474307907,
-    "wof:geomhash":"ebfdf7c342076a4a75cd0aa06a92d53e",
+    "wof:geomhash":"9b264f2c514099b5480af2dcfa9f62e0",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -151,7 +152,7 @@
         }
     ],
     "wof:id":1108691321,
-    "wof:lastmodified":1690921389,
+    "wof:lastmodified":1695886289,
     "wof:name":"Kvareli",
     "wof:parent_id":1108805939,
     "wof:placetype":"county",

--- a/data/110/869/132/3/1108691323.geojson
+++ b/data/110/869/132/3/1108691323.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.096938,
-    "geom:area_square_m":893330221.457545,
+    "geom:area_square_m":893329777.639684,
     "geom:bbox":"45.903927,41.589478,46.428474,42.006756",
     "geom:latitude":41.817383,
     "geom:longitude":46.167419,
@@ -133,9 +133,10 @@
         "hasc:id":"GE.KA.LG",
         "wd:id":"Q941140"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GE",
     "wof:created":1474307908,
-    "wof:geomhash":"c8898f2bedb19b25807f040af996d96a",
+    "wof:geomhash":"8c347edb411ac397a19aea138cfb01e5",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -145,7 +146,7 @@
         }
     ],
     "wof:id":1108691323,
-    "wof:lastmodified":1690921390,
+    "wof:lastmodified":1695886289,
     "wof:name":"Lagodekhi",
     "wof:parent_id":1108805939,
     "wof:placetype":"county",

--- a/data/110/869/132/7/1108691327.geojson
+++ b/data/110/869/132/7/1108691327.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.065627,
-    "geom:area_square_m":602285534.494507,
+    "geom:area_square_m":602285465.602874,
     "geom:bbox":"41.711643,41.972527,42.225502,42.184814",
     "geom:latitude":42.081329,
     "geom:longitude":41.964255,
@@ -147,9 +147,10 @@
         "hasc:id":"GE.GU.LK",
         "wd:id":"Q2380601"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GE",
     "wof:created":1474307909,
-    "wof:geomhash":"61ad5a4ffddd2d3e79e823831536a083",
+    "wof:geomhash":"e644fdf5be62d1983fcc27eef3f1b340",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -159,7 +160,7 @@
         }
     ],
     "wof:id":1108691327,
-    "wof:lastmodified":1690921389,
+    "wof:lastmodified":1695886290,
     "wof:name":"Lanchkhuti",
     "wof:parent_id":1108805955,
     "wof:placetype":"county",

--- a/data/110/869/132/9/1108691329.geojson
+++ b/data/110/869/132/9/1108691329.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.16113,
-    "geom:area_square_m":1461538138.561052,
+    "geom:area_square_m":1461538634.992922,
     "geom:bbox":"42.35825,42.659615,43.337299,42.965092",
     "geom:latitude":42.814834,
     "geom:longitude":42.844222,
@@ -136,9 +136,10 @@
         "hasc:id":"GE.RK.LE",
         "wd:id":"Q2464174"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GE",
     "wof:created":1474307911,
-    "wof:geomhash":"fb0c9c8fff92b68ac318e04d8018c184",
+    "wof:geomhash":"bb4219b2a0819c2335f4faa3d7c9d877",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -148,7 +149,7 @@
         }
     ],
     "wof:id":1108691329,
-    "wof:lastmodified":1690921388,
+    "wof:lastmodified":1695886290,
     "wof:name":"Lentekhi",
     "wof:parent_id":1108805959,
     "wof:placetype":"county",

--- a/data/110/869/133/1/1108691331.geojson
+++ b/data/110/869/133/1/1108691331.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.102085,
-    "geom:area_square_m":947412923.234558,
+    "geom:area_square_m":947412656.054902,
     "geom:bbox":"44.527973,41.186752,45.09346,41.549706",
     "geom:latitude":41.362115,
     "geom:longitude":44.835599,
@@ -135,9 +135,10 @@
         "hasc:id":"GE.KK.MN",
         "wd:id":"Q2410306"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GE",
     "wof:created":1474307913,
-    "wof:geomhash":"526e1c0fa20752ab274f50bf7e1a61af",
+    "wof:geomhash":"4e8292fcd4872cd4a7e655c7e19cec24",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -147,7 +148,7 @@
         }
     ],
     "wof:id":1108691331,
-    "wof:lastmodified":1690921391,
+    "wof:lastmodified":1695886290,
     "wof:name":"Marneuli",
     "wof:parent_id":1108805951,
     "wof:placetype":"county",

--- a/data/110/869/133/3/1108691333.geojson
+++ b/data/110/869/133/3/1108691333.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.098336,
-    "geom:area_square_m":896088850.05051,
+    "geom:area_square_m":896088379.381971,
     "geom:bbox":"42.174927,42.283634,42.617844,42.774544",
     "geom:latitude":42.527808,
     "geom:longitude":42.391835,
@@ -139,9 +139,10 @@
         "hasc:id":"GE.SZ.MV",
         "wd:id":"Q2511190"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GE",
     "wof:created":1474307914,
-    "wof:geomhash":"0527c9f644cb6c104fed55b50fa720cf",
+    "wof:geomhash":"203cfc52c4b5aed9113261145942ceab",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -151,7 +152,7 @@
         }
     ],
     "wof:id":1108691333,
-    "wof:lastmodified":1690921391,
+    "wof:lastmodified":1695886290,
     "wof:name":"Martvili",
     "wof:parent_id":1108805935,
     "wof:placetype":"county",

--- a/data/110/869/133/5/1108691335.geojson
+++ b/data/110/869/133/5/1108691335.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.338947,
-    "geom:area_square_m":3064422292.634588,
+    "geom:area_square_m":3064421731.205495,
     "geom:bbox":"41.862755,42.805546,43.149185,43.254871",
     "geom:latitude":43.015739,
     "geom:longitude":42.470326,
@@ -131,9 +131,10 @@
         "hasc:id":"GE.SZ.MS",
         "wd:id":"Q2490962"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GE",
     "wof:created":1474307915,
-    "wof:geomhash":"861c20d07e936136649a158e90cafb07",
+    "wof:geomhash":"8fa0bf5cab574967e6e8eb20fcce1322",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -143,7 +144,7 @@
         }
     ],
     "wof:id":1108691335,
-    "wof:lastmodified":1690921392,
+    "wof:lastmodified":1695886290,
     "wof:name":"Mestia",
     "wof:parent_id":1108805935,
     "wof:placetype":"county",

--- a/data/110/869/133/7/1108691337.geojson
+++ b/data/110/869/133/7/1108691337.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.078976,
-    "geom:area_square_m":727309506.363901,
+    "geom:area_square_m":727308879.274425,
     "geom:bbox":"44.47374,41.687515,45.066444,41.994427",
     "geom:latitude":41.860261,
     "geom:longitude":44.704131,
@@ -149,9 +149,10 @@
         "hasc:id":"GE.MM.MK",
         "wd:id":"Q2266679"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GE",
     "wof:created":1474307917,
-    "wof:geomhash":"3298f3bbd1079d6dcc90848f737d6f8f",
+    "wof:geomhash":"6aecb8e00d25a10b30cce71e54679b45",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -161,7 +162,7 @@
         }
     ],
     "wof:id":1108691337,
-    "wof:lastmodified":1690921391,
+    "wof:lastmodified":1695886290,
     "wof:name":"Mtskheta",
     "wof:parent_id":1108805943,
     "wof:placetype":"county",

--- a/data/110/869/133/9/1108691339.geojson
+++ b/data/110/869/133/9/1108691339.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.146033,
-    "geom:area_square_m":1356711304.599575,
+    "geom:area_square_m":1356711615.987208,
     "geom:bbox":"43.430244,41.10561,43.966663,41.534966",
     "geom:latitude":41.293521,
     "geom:longitude":43.7165,
@@ -140,9 +140,10 @@
         "hasc:id":"GE.SJ.NI",
         "wd:id":"Q1025123"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GE",
     "wof:created":1474307918,
-    "wof:geomhash":"cdfa2466a51988ec6c64acc2037cdc22",
+    "wof:geomhash":"4862e5c7537599a7bfd744d3457bad6e",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -152,7 +153,7 @@
         }
     ],
     "wof:id":1108691339,
-    "wof:lastmodified":1690921390,
+    "wof:lastmodified":1695886290,
     "wof:name":"Ninotsminda",
     "wof:parent_id":1108805953,
     "wof:placetype":"county",

--- a/data/110/869/134/1/1108691341.geojson
+++ b/data/110/869/134/1/1108691341.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.211688,
-    "geom:area_square_m":1917167424.303116,
+    "geom:area_square_m":1917167424.303088,
     "geom:bbox":"41.1499633789,42.6416549683,42.1544647217,43.196598053",
     "geom:latitude":42.909916,
     "geom:longitude":41.606463,
@@ -185,9 +185,10 @@
     "wof:concordances":{
         "hasc:id":"GE.AB.OC"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GE",
     "wof:created":1474307920,
-    "wof:geomhash":"66c7d735dc373107bfc9df48c0587ea8",
+    "wof:geomhash":"7e773133673bae6d2a216ab0e311ff34",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -197,7 +198,7 @@
         }
     ],
     "wof:id":1108691341,
-    "wof:lastmodified":1566637097,
+    "wof:lastmodified":1695886290,
     "wof:name":"Ochamchire",
     "wof:parent_id":1108805957,
     "wof:placetype":"county",

--- a/data/110/869/134/5/1108691345.geojson
+++ b/data/110/869/134/5/1108691345.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.191746,
-    "geom:area_square_m":1744206959.325463,
+    "geom:area_square_m":1744207036.944753,
     "geom:bbox":"43.237808,42.429245,43.950596,42.893967",
     "geom:latitude":42.637721,
     "geom:longitude":43.53995,
@@ -133,9 +133,10 @@
         "hasc:id":"GE.RK.ON",
         "wd:id":"Q893287"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GE",
     "wof:created":1474307921,
-    "wof:geomhash":"c5d93c1577e32cb0b0558e847162a45b",
+    "wof:geomhash":"aaeaf009d2fe279d1d9570eafe575181",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -145,7 +146,7 @@
         }
     ],
     "wof:id":1108691345,
-    "wof:lastmodified":1690921393,
+    "wof:lastmodified":1695886290,
     "wof:name":"Oni",
     "wof:parent_id":1108805959,
     "wof:placetype":"county",

--- a/data/110/869/134/7/1108691347.geojson
+++ b/data/110/869/134/7/1108691347.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.072294,
-    "geom:area_square_m":665225999.499446,
+    "geom:area_square_m":665225375.256022,
     "geom:bbox":"41.754929,41.779629,42.292572,42.034088",
     "geom:latitude":41.91328,
     "geom:longitude":42.031369,
@@ -149,9 +149,10 @@
         "hasc:id":"GE.GU.OZ",
         "wd:id":"Q510761"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GE",
     "wof:created":1474307923,
-    "wof:geomhash":"891a90719fe587d1204c502d2a6760f2",
+    "wof:geomhash":"fd1d29182aaa2bea0ef2569172f803f4",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -161,7 +162,7 @@
         }
     ],
     "wof:id":1108691347,
-    "wof:lastmodified":1690921393,
+    "wof:lastmodified":1695886290,
     "wof:name":"Ozurgeti",
     "wof:parent_id":1108805955,
     "wof:placetype":"county",

--- a/data/110/869/134/9/1108691349.geojson
+++ b/data/110/869/134/9/1108691349.geojson
@@ -124,6 +124,7 @@
         "hasc:id":"GE.SZ.KH",
         "wd:id":"Q2475615"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GE",
     "wof:created":1474307924,
     "wof:geomhash":"b1506a0ddea63f9c8dc86ba8c6dc043c",
@@ -136,7 +137,7 @@
         }
     ],
     "wof:id":1108691349,
-    "wof:lastmodified":1694497838,
+    "wof:lastmodified":1695886290,
     "wof:name":"Poti City",
     "wof:parent_id":1108805935,
     "wof:placetype":"county",

--- a/data/110/869/135/1/1108691351.geojson
+++ b/data/110/869/135/1/1108691351.geojson
@@ -122,6 +122,7 @@
         "hasc:id":"GE.KK.GD",
         "wd:id":"Q2512996"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GE",
     "wof:created":1474307925,
     "wof:geomhash":"f041dbca1667281902c595abdad6941f",
@@ -134,7 +135,7 @@
         }
     ],
     "wof:id":1108691351,
-    "wof:lastmodified":1694497838,
+    "wof:lastmodified":1695886290,
     "wof:name":"Rustavi City",
     "wof:parent_id":1108805951,
     "wof:placetype":"county",

--- a/data/110/869/135/3/1108691353.geojson
+++ b/data/110/869/135/3/1108691353.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.099824,
-    "geom:area_square_m":912773533.049954,
+    "geom:area_square_m":912773156.21181,
     "geom:bbox":"43.260197,42.082752,43.790142,42.456337",
     "geom:latitude":42.312655,
     "geom:longitude":43.52314,
@@ -143,9 +143,10 @@
         "hasc:id":"GE.IM.SC",
         "wd:id":"Q893325"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GE",
     "wof:created":1474307927,
-    "wof:geomhash":"2eeea6d2333307005ac5748c2f2cfeb2",
+    "wof:geomhash":"0f4e6eae3f9ad0cafa74d6276183b01b",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -155,7 +156,7 @@
         }
     ],
     "wof:id":1108691353,
-    "wof:lastmodified":1690921387,
+    "wof:lastmodified":1695886290,
     "wof:name":"Sachkhere",
     "wof:parent_id":1108805937,
     "wof:placetype":"county",

--- a/data/110/869/135/5/1108691355.geojson
+++ b/data/110/869/135/5/1108691355.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.165109,
-    "geom:area_square_m":1525328759.8928,
+    "geom:area_square_m":1525328766.501448,
     "geom:bbox":"45.022861,41.408195,45.642952,41.918953",
     "geom:latitude":41.658126,
     "geom:longitude":45.372545,
@@ -134,9 +134,10 @@
         "hasc:id":"GE.KA.SG",
         "wd:id":"Q1647344"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GE",
     "wof:created":1474307928,
-    "wof:geomhash":"0e21725fee2785172a6ee5d492edf076",
+    "wof:geomhash":"75d54d7760b2ee941e024628af5564f3",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -146,7 +147,7 @@
         }
     ],
     "wof:id":1108691355,
-    "wof:lastmodified":1690921388,
+    "wof:lastmodified":1695886290,
     "wof:name":"Sagarejo",
     "wof:parent_id":1108805939,
     "wof:placetype":"county",

--- a/data/110/869/135/7/1108691357.geojson
+++ b/data/110/869/135/7/1108691357.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.038325,
-    "geom:area_square_m":351343403.578122,
+    "geom:area_square_m":351343157.898036,
     "geom:bbox":"42.213947,41.995102,42.541195,42.271587",
     "geom:latitude":42.150102,
     "geom:longitude":42.371667,
@@ -139,9 +139,10 @@
         "hasc:id":"GE.IM.SM",
         "wd:id":"Q2142574"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GE",
     "wof:created":1474307930,
-    "wof:geomhash":"2412d5d2331377a94bc8655e420b190d",
+    "wof:geomhash":"1ea4cac9878c0e37fcdd83ef08967974",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -151,7 +152,7 @@
         }
     ],
     "wof:id":1108691357,
-    "wof:lastmodified":1690921387,
+    "wof:lastmodified":1695886289,
     "wof:name":"Samtredia",
     "wof:parent_id":1108805937,
     "wof:placetype":"county",

--- a/data/110/869/135/9/1108691359.geojson
+++ b/data/110/869/135/9/1108691359.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.056375,
-    "geom:area_square_m":515604180.293828,
+    "geom:area_square_m":515604287.552223,
     "geom:bbox":"41.868538,42.139465,42.270252,42.452106",
     "geom:latitude":42.298395,
     "geom:longitude":42.084163,
@@ -128,9 +128,10 @@
         "hasc:id":"GE.SZ.SN",
         "wd:id":"Q2490876"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GE",
     "wof:created":1474307931,
-    "wof:geomhash":"563c1b112eeab03cd01686ca069ca96a",
+    "wof:geomhash":"ead0e64cc4b74304596f20759f6d2ae6",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -140,7 +141,7 @@
         }
     ],
     "wof:id":1108691359,
-    "wof:lastmodified":1690921386,
+    "wof:lastmodified":1695886289,
     "wof:name":"Senaki",
     "wof:parent_id":1108805935,
     "wof:placetype":"county",

--- a/data/110/869/136/3/1108691363.geojson
+++ b/data/110/869/136/3/1108691363.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.062659,
-    "geom:area_square_m":579373329.992921,
+    "geom:area_square_m":579373404.782801,
     "geom:bbox":"42.098408,41.431664,42.522564,41.804951",
     "geom:latitude":41.601539,
     "geom:longitude":42.250523,
@@ -131,9 +131,10 @@
         "hasc:id":"GE.AJ.SH",
         "wd:id":"Q660888"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GE",
     "wof:created":1474307932,
-    "wof:geomhash":"30a91363560aa84abe3ec65fd055673c",
+    "wof:geomhash":"98e0f9f92ee842c5272033321c229515",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -143,7 +144,7 @@
         }
     ],
     "wof:id":1108691363,
-    "wof:lastmodified":1690921400,
+    "wof:lastmodified":1695886292,
     "wof:name":"Shuakhevi",
     "wof:parent_id":1108805947,
     "wof:placetype":"county",

--- a/data/110/869/136/5/1108691365.geojson
+++ b/data/110/869/136/5/1108691365.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.136798,
-    "geom:area_square_m":1266792517.898911,
+    "geom:area_square_m":1266792807.364395,
     "geom:bbox":"45.533695,41.248634,46.385559,41.700588",
     "geom:latitude":41.504505,
     "geom:longitude":45.933317,
@@ -134,9 +134,10 @@
         "hasc:id":"GE.KA.SI",
         "wd:id":"Q1953363"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GE",
     "wof:created":1474307934,
-    "wof:geomhash":"dc816028ce32d9054f81fa683d0c6cb3",
+    "wof:geomhash":"b80e46d24670d5dc8ca1285fa3d992f5",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -146,7 +147,7 @@
         }
     ],
     "wof:id":1108691365,
-    "wof:lastmodified":1690921400,
+    "wof:lastmodified":1695886292,
     "wof:name":"Sighnagi",
     "wof:parent_id":1108805939,
     "wof:placetype":"county",

--- a/data/110/869/136/7/1108691367.geojson
+++ b/data/110/869/136/7/1108691367.geojson
@@ -55,6 +55,7 @@
     "wof:concordances":{
         "hasc:id":"GE.AB.SU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GE",
     "wof:created":1474307935,
     "wof:geomhash":"2ca6e06b19060e83dc847f4b53b1e4f8",
@@ -67,7 +68,7 @@
         }
     ],
     "wof:id":1108691367,
-    "wof:lastmodified":1694498076,
+    "wof:lastmodified":1695886403,
     "wof:name":"Sokhumi",
     "wof:parent_id":1108805957,
     "wof:placetype":"county",

--- a/data/110/869/136/9/1108691369.geojson
+++ b/data/110/869/136/9/1108691369.geojson
@@ -55,6 +55,7 @@
     "wof:concordances":{
         "hasc:id":"GE.AB.SU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GE",
     "wof:created":1474307937,
     "wof:geomhash":"e254729bfb07ea9faf7e0ea9d0e2e42f",
@@ -67,7 +68,7 @@
         }
     ],
     "wof:id":1108691369,
-    "wof:lastmodified":1694498076,
+    "wof:lastmodified":1695886403,
     "wof:name":"Sokhumi City",
     "wof:parent_id":1108805957,
     "wof:placetype":"county",

--- a/data/110/869/137/3/1108691373.geojson
+++ b/data/110/869/137/3/1108691373.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.125082,
-    "geom:area_square_m":1149016302.620066,
+    "geom:area_square_m":1149016643.686842,
     "geom:bbox":"45.274731,41.795143,45.741722,42.291618",
     "geom:latitude":42.020791,
     "geom:longitude":45.507415,
@@ -139,9 +139,10 @@
         "hasc:id":"GE.KA.TE",
         "wd:id":"Q1953364"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GE",
     "wof:created":1474307939,
-    "wof:geomhash":"c3cbc95e6e5bafa4ce9a4bd46838fa03",
+    "wof:geomhash":"96092071388d4108a881a59406e76bbe",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -151,7 +152,7 @@
         }
     ],
     "wof:id":1108691373,
-    "wof:lastmodified":1690921404,
+    "wof:lastmodified":1695886293,
     "wof:name":"Telavi",
     "wof:parent_id":1108805939,
     "wof:placetype":"county",

--- a/data/110/869/137/5/1108691375.geojson
+++ b/data/110/869/137/5/1108691375.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.038429,
-    "geom:area_square_m":351866624.092963,
+    "geom:area_square_m":351866977.178353,
     "geom:bbox":"42.719093,42.148792,43.134865,42.298771",
     "geom:latitude":42.227651,
     "geom:longitude":42.928319,
@@ -137,9 +137,10 @@
         "hasc:id":"GE.IM.TJ",
         "wd:id":"Q2374974"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GE",
     "wof:created":1474307941,
-    "wof:geomhash":"2c9c186516e8c195a8754fe77d2a7147",
+    "wof:geomhash":"8009436c6c3ddd76f75a9e14355e2b90",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -149,7 +150,7 @@
         }
     ],
     "wof:id":1108691375,
-    "wof:lastmodified":1690921405,
+    "wof:lastmodified":1695886293,
     "wof:name":"Terjola",
     "wof:parent_id":1108805937,
     "wof:placetype":"county",

--- a/data/110/869/137/7/1108691377.geojson
+++ b/data/110/869/137/7/1108691377.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.130585,
-    "geom:area_square_m":1207536829.020781,
+    "geom:area_square_m":1207536873.620386,
     "geom:bbox":"44.197208,41.42503,44.831032,41.76828",
     "geom:latitude":41.596812,
     "geom:longitude":44.474892,
@@ -144,9 +144,10 @@
         "hasc:id":"GE.KK.TR",
         "wd:id":"Q1954407"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GE",
     "wof:created":1474307943,
-    "wof:geomhash":"1c6fa44f734c88874de9abab62916b33",
+    "wof:geomhash":"dcb270233bbce7963a30002ddfb3d512",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -156,7 +157,7 @@
         }
     ],
     "wof:id":1108691377,
-    "wof:lastmodified":1690921404,
+    "wof:lastmodified":1695886292,
     "wof:name":"Tetri Tskaro",
     "wof:parent_id":1108805951,
     "wof:placetype":"county",

--- a/data/110/869/138/1/1108691381.geojson
+++ b/data/110/869/138/1/1108691381.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.098658,
-    "geom:area_square_m":904826144.938714,
+    "geom:area_square_m":904826129.32458,
     "geom:bbox":"44.851967,41.887169,45.244083,42.380604",
     "geom:latitude":42.122628,
     "geom:longitude":45.009202,
@@ -130,9 +130,10 @@
         "hasc:id":"GE.MM.TI",
         "wd:id":"Q2586447"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GE",
     "wof:created":1474307944,
-    "wof:geomhash":"e9c5536cb7dc189a1fe070f322a872e6",
+    "wof:geomhash":"7b0483881e81507bcae07663cbd487ec",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -142,7 +143,7 @@
         }
     ],
     "wof:id":1108691381,
-    "wof:lastmodified":1690921402,
+    "wof:lastmodified":1695886292,
     "wof:name":"Tianeti",
     "wof:parent_id":1108805943,
     "wof:placetype":"county",

--- a/data/110/869/138/3/1108691383.geojson
+++ b/data/110/869/138/3/1108691383.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.05155,
-    "geom:area_square_m":471058106.355314,
+    "geom:area_square_m":471058106.355247,
     "geom:bbox":"42.7323303223,42.2602653503,43.13621521,42.4825973511",
     "geom:latitude":42.353388,
     "geom:longitude":42.915413,
@@ -165,9 +165,10 @@
     "wof:concordances":{
         "hasc:id":"GE.IM.TQ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GE",
     "wof:created":1474307945,
-    "wof:geomhash":"67fe723287c1b88d5666bb28f15bde7c",
+    "wof:geomhash":"a81a12d895a69893f4fe1ae18a0ffce9",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -177,7 +178,7 @@
         }
     ],
     "wof:id":1108691383,
-    "wof:lastmodified":1566637103,
+    "wof:lastmodified":1695886292,
     "wof:name":"Tkibuli",
     "wof:parent_id":1108805937,
     "wof:placetype":"county",

--- a/data/110/869/138/5/1108691385.geojson
+++ b/data/110/869/138/5/1108691385.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.079232,
-    "geom:area_square_m":720912308.124511,
+    "geom:area_square_m":720912535.904259,
     "geom:bbox":"42.528481,42.462124,43.107182,42.767601",
     "geom:latitude":42.622014,
     "geom:longitude":42.792282,
@@ -134,9 +134,10 @@
         "hasc:id":"GE.RK.TG",
         "wd:id":"Q2489909"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GE",
     "wof:created":1474307947,
-    "wof:geomhash":"8a6d4703f1a644b9568e5b95846ff51c",
+    "wof:geomhash":"9b6d55db0121b8dc95fc404d62c0065e",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -146,7 +147,7 @@
         }
     ],
     "wof:id":1108691385,
-    "wof:lastmodified":1690921402,
+    "wof:lastmodified":1695886292,
     "wof:name":"Tsageri",
     "wof:parent_id":1108805959,
     "wof:placetype":"county",

--- a/data/110/869/138/7/1108691387.geojson
+++ b/data/110/869/138/7/1108691387.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.073453,
-    "geom:area_square_m":667367347.073369,
+    "geom:area_square_m":667367523.037613,
     "geom:bbox":"41.884239,42.509357,42.254169,42.856281",
     "geom:latitude":42.712061,
     "geom:longitude":42.066701,
@@ -146,9 +146,10 @@
         "hasc:id":"GE.SZ.TL",
         "wd:id":"Q2475606"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GE",
     "wof:created":1474307948,
-    "wof:geomhash":"c4d7ccd02e7fc5ea39732865b7e7233d",
+    "wof:geomhash":"35d435e1e34f138a1299f9d4cca94e70",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -158,7 +159,7 @@
         }
     ],
     "wof:id":1108691387,
-    "wof:lastmodified":1690921401,
+    "wof:lastmodified":1695886292,
     "wof:name":"Tsalenjikha",
     "wof:parent_id":1108805935,
     "wof:placetype":"county",

--- a/data/110/869/138/9/1108691389.geojson
+++ b/data/110/869/138/9/1108691389.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.112811,
-    "geom:area_square_m":1042844395.10676,
+    "geom:area_square_m":1042844380.219047,
     "geom:bbox":"43.672138,41.478497,44.260029,41.762165",
     "geom:latitude":41.617389,
     "geom:longitude":43.97101,
@@ -140,9 +140,10 @@
         "hasc:id":"GE.KK.TK",
         "wd:id":"Q2238147"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GE",
     "wof:created":1474307950,
-    "wof:geomhash":"12a3d00a69b2ad8214ccb42e4b6b8689",
+    "wof:geomhash":"cfb367040dc7a4ee0144ea96825d069b",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -152,7 +153,7 @@
         }
     ],
     "wof:id":1108691389,
-    "wof:lastmodified":1690921401,
+    "wof:lastmodified":1695886292,
     "wof:name":"Tsalka",
     "wof:parent_id":1108805951,
     "wof:placetype":"county",

--- a/data/110/869/139/1/1108691391.geojson
+++ b/data/110/869/139/1/1108691391.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.076904,
-    "geom:area_square_m":703302196.713238,
+    "geom:area_square_m":703301755.680886,
     "geom:bbox":"42.451927,42.103775,42.887825,42.506596",
     "geom:latitude":42.30308,
     "geom:longitude":42.646823,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"GE.IM.TS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GE",
     "wof:created":1474307951,
-    "wof:geomhash":"3ba4d97028c1160513120d3f4e9ed822",
+    "wof:geomhash":"76f57280107ded5d683e5be7979094ea",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1108691391,
-    "wof:lastmodified":1627522152,
+    "wof:lastmodified":1695886621,
     "wof:name":"Tskaltubo",
     "wof:parent_id":1108805937,
     "wof:placetype":"county",

--- a/data/110/869/139/3/1108691393.geojson
+++ b/data/110/869/139/3/1108691393.geojson
@@ -135,6 +135,7 @@
         "hasc:id":"GE.SD.GR",
         "wd:id":"Q1417170"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GE",
     "wof:created":1474307953,
     "wof:geomhash":"6dcc692e5ddb78af123e4915d5dff0cc",
@@ -147,7 +148,7 @@
         }
     ],
     "wof:id":1108691393,
-    "wof:lastmodified":1694497838,
+    "wof:lastmodified":1695886292,
     "wof:name":"Tskhinvali",
     "wof:parent_id":1108805941,
     "wof:placetype":"county",

--- a/data/110/869/139/5/1108691395.geojson
+++ b/data/110/869/139/5/1108691395.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.065001,
-    "geom:area_square_m":597203115.825086,
+    "geom:area_square_m":597203118.631126,
     "geom:bbox":"42.394531,41.809982,42.804276,42.134426",
     "geom:latitude":42.010694,
     "geom:longitude":42.610405,
@@ -133,9 +133,10 @@
         "hasc:id":"GE.IM.VA",
         "wd:id":"Q893220"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GE",
     "wof:created":1474307954,
-    "wof:geomhash":"f7bea42a33bd88fdca16bcf99dcb04f8",
+    "wof:geomhash":"b8a5ed0283ba81bc4becf8567f51f999",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -145,7 +146,7 @@
         }
     ],
     "wof:id":1108691395,
-    "wof:lastmodified":1690921404,
+    "wof:lastmodified":1695886292,
     "wof:name":"Vani",
     "wof:parent_id":1108805937,
     "wof:placetype":"county",

--- a/data/110/869/139/9/1108691399.geojson
+++ b/data/110/869/139/9/1108691399.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.047503,
-    "geom:area_square_m":435624390.400349,
+    "geom:area_square_m":435624125.961297,
     "geom:bbox":"42.760105,42.028488,43.229229,42.229378",
     "geom:latitude":42.128967,
     "geom:longitude":43.048986,
@@ -143,9 +143,10 @@
         "hasc:id":"GE.IM.ZP",
         "wd:id":"Q2464187"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GE",
     "wof:created":1474307956,
-    "wof:geomhash":"b9fc86320e969c789cfe691a28374e77",
+    "wof:geomhash":"c0efd6eeb7572a0160e36e13397f3ce5",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -155,7 +156,7 @@
         }
     ],
     "wof:id":1108691399,
-    "wof:lastmodified":1690921403,
+    "wof:lastmodified":1695886292,
     "wof:name":"Zestafoni",
     "wof:parent_id":1108805937,
     "wof:placetype":"county",

--- a/data/110/869/140/1/1108691401.geojson
+++ b/data/110/869/140/1/1108691401.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.074976,
-    "geom:area_square_m":683912515.670804,
+    "geom:area_square_m":683912233.766548,
     "geom:bbox":"41.547092,42.311184,42.041309,42.630035",
     "geom:latitude":42.464155,
     "geom:longitude":41.820088,
@@ -136,9 +136,10 @@
         "hasc:id":"GE.SZ.ZG",
         "wd:id":"Q2176973"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GE",
     "wof:created":1474307957,
-    "wof:geomhash":"ad58ffe772a75c0a944f1a1194aaa6a1",
+    "wof:geomhash":"6cc4f257277235c796bdd302e7d2965a",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -148,7 +149,7 @@
         }
     ],
     "wof:id":1108691401,
-    "wof:lastmodified":1690921411,
+    "wof:lastmodified":1695886293,
     "wof:name":"Zugdidi",
     "wof:parent_id":1108805935,
     "wof:placetype":"county",

--- a/data/110/880/593/5/1108805935.geojson
+++ b/data/110/880/593/5/1108805935.geojson
@@ -43,8 +43,10 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"GE.SZ"
+        "hasc:id":"GE.SZ",
+        "iso:code":"GE-SZ"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"GE",
     "wof:created":1485972930,
     "wof:geomhash":"ec6db92765fcf3f8573461bd5b1573eb",
@@ -64,7 +66,7 @@
         "abk",
         "oss"
     ],
-    "wof:lastmodified":1694493127,
+    "wof:lastmodified":1695884285,
     "wof:name":"Samagrelo-Zemo Svaneti",
     "wof:parent_id":85633163,
     "wof:placetype":"region",

--- a/data/110/880/593/7/1108805937.geojson
+++ b/data/110/880/593/7/1108805937.geojson
@@ -235,7 +235,7 @@
         "abk",
         "oss"
     ],
-    "wof:lastmodified":1695880874,
+    "wof:lastmodified":1695884280,
     "wof:name":"Imereti",
     "wof:parent_id":85633163,
     "wof:placetype":"region",

--- a/data/110/880/593/7/1108805937.geojson
+++ b/data/110/880/593/7/1108805937.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.714903,
-    "geom:area_square_m":6551139250.750518,
+    "geom:area_square_m":6551139250.750624,
     "geom:bbox":"42.2139472961,41.8040962219,43.7901420593,42.5611114502",
     "geom:latitude":42.175727,
     "geom:longitude":42.96932,
@@ -23,7 +23,7 @@
     "lbl:longitude":42.954254,
     "lbl:min_zoom":8.0,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:max_zoom":11.0,
     "mz:min_zoom":7.7,
     "name:abk_x_preferred":[
@@ -212,11 +212,13 @@
     "wof:concordances":{
         "fips:code":"GG66",
         "hasc:id":"GE.IM",
+        "iso:code":"GE-IM",
         "iso:id":"GE-IM"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"GE",
     "wof:created":1485972930,
-    "wof:geomhash":"c34557793ef530a76001f44a3a58c207",
+    "wof:geomhash":"3bebfdb147709e8ee4f58b45a0b5e21c",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -233,7 +235,7 @@
         "abk",
         "oss"
     ],
-    "wof:lastmodified":1566637092,
+    "wof:lastmodified":1695880874,
     "wof:name":"Imereti",
     "wof:parent_id":85633163,
     "wof:placetype":"region",

--- a/data/110/880/593/9/1108805939.geojson
+++ b/data/110/880/593/9/1108805939.geojson
@@ -216,7 +216,7 @@
         "abk",
         "oss"
     ],
-    "wof:lastmodified":1695880874,
+    "wof:lastmodified":1695884280,
     "wof:name":"Kakheti",
     "wof:parent_id":85633163,
     "wof:placetype":"region",

--- a/data/110/880/593/9/1108805939.geojson
+++ b/data/110/880/593/9/1108805939.geojson
@@ -193,8 +193,10 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"GE.KA"
+        "hasc:id":"GE.KA",
+        "iso:code":"GE-KA"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"GE",
     "wof:created":1485972931,
     "wof:geomhash":"cbd19e9f576b695a241b8a908b920f98",
@@ -214,7 +216,7 @@
         "abk",
         "oss"
     ],
-    "wof:lastmodified":1694493125,
+    "wof:lastmodified":1695880874,
     "wof:name":"Kakheti",
     "wof:parent_id":85633163,
     "wof:placetype":"region",

--- a/data/110/880/594/1/1108805941.geojson
+++ b/data/110/880/594/1/1108805941.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.62188,
-    "geom:area_square_m":5703787791.031981,
+    "geom:area_square_m":5703787791.03195,
     "geom:bbox":"43.4227409363,41.730381012,44.5734291077,42.6275482178",
     "geom:latitude":42.119074,
     "geom:longitude":44.01954,
@@ -23,7 +23,7 @@
     "lbl:longitude":43.951089,
     "lbl:min_zoom":8.0,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:max_zoom":11.0,
     "mz:min_zoom":7.7,
     "name:abk_x_preferred":[
@@ -197,11 +197,13 @@
     "wof:concordances":{
         "fips:code":"GG73",
         "hasc:id":"GE.SD",
+        "iso:code":"GE-SK",
         "iso:id":"GE-SK"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"GE",
     "wof:created":1485972931,
-    "wof:geomhash":"81a3cc4fbba526c9aa7515d02643eaa3",
+    "wof:geomhash":"08212b137a6b5394b72721720168d38a",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -218,7 +220,7 @@
         "abk",
         "oss"
     ],
-    "wof:lastmodified":1566637091,
+    "wof:lastmodified":1695880874,
     "wof:name":"Shida Kartli",
     "wof:parent_id":85633163,
     "wof:placetype":"region",

--- a/data/110/880/594/1/1108805941.geojson
+++ b/data/110/880/594/1/1108805941.geojson
@@ -220,7 +220,7 @@
         "abk",
         "oss"
     ],
-    "wof:lastmodified":1695880874,
+    "wof:lastmodified":1695884280,
     "wof:name":"Shida Kartli",
     "wof:parent_id":85633163,
     "wof:placetype":"region",

--- a/data/110/880/594/3/1108805943.geojson
+++ b/data/110/880/594/3/1108805943.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.728009,
-    "geom:area_square_m":6657820309.03792,
+    "geom:area_square_m":6657820309.037666,
     "geom:bbox":"44.2221412659,41.6875152588,45.3108863831,42.7619590759",
     "geom:latitude":42.302335,
     "geom:longitude":44.751694,
@@ -23,7 +23,7 @@
     "lbl:longitude":44.741219,
     "lbl:min_zoom":8.0,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:max_zoom":11.0,
     "mz:min_zoom":7.7,
     "name:abk_x_preferred":[
@@ -197,11 +197,13 @@
     "wof:concordances":{
         "fips:code":"GG69",
         "hasc:id":"GE.MM",
+        "iso:code":"GE-MM",
         "iso:id":"GE-MM"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"GE",
     "wof:created":1485972931,
-    "wof:geomhash":"6845318b3971803b54d29a69c858332d",
+    "wof:geomhash":"c36b25aef31cbb75ee437ae4b79a621b",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -218,7 +220,7 @@
         "abk",
         "oss"
     ],
-    "wof:lastmodified":1566637092,
+    "wof:lastmodified":1695880874,
     "wof:name":"Mtskheta-Mtianeti",
     "wof:parent_id":85633163,
     "wof:placetype":"region",

--- a/data/110/880/594/3/1108805943.geojson
+++ b/data/110/880/594/3/1108805943.geojson
@@ -220,7 +220,7 @@
         "abk",
         "oss"
     ],
-    "wof:lastmodified":1695880874,
+    "wof:lastmodified":1695884280,
     "wof:name":"Mtskheta-Mtianeti",
     "wof:parent_id":85633163,
     "wof:placetype":"region",

--- a/data/110/880/594/5/1108805945.geojson
+++ b/data/110/880/594/5/1108805945.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.054701,
-    "geom:area_square_m":504890248.730025,
+    "geom:area_square_m":504890248.730037,
     "geom:bbox":"44.596981,41.616703,45.016941,41.837799",
     "geom:latitude":41.716419,
     "geom:longitude":44.812351,
@@ -23,7 +23,7 @@
     "lbl:longitude":44.787378,
     "lbl:min_zoom":8.0,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:max_zoom":11.0,
     "mz:min_zoom":7.7,
     "name:abk_x_preferred":[
@@ -542,14 +542,16 @@
     "wof:concordances":{
         "fips:code":"GG51",
         "hasc:id":"GE.TB",
+        "iso:code":"GE-TB",
         "iso:id":"GE-TB"
     },
+    "wof:concordances_official":"iso:code",
     "wof:coterminous":[
         890443227
     ],
     "wof:country":"GE",
     "wof:created":1485972931,
-    "wof:geomhash":"46e705997f1d67b5383238145f700173",
+    "wof:geomhash":"5f5b08f0df32d3bec7d14808ba240349",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -566,7 +568,7 @@
         "abk",
         "oss"
     ],
-    "wof:lastmodified":1608054816,
+    "wof:lastmodified":1695884282,
     "wof:name":"Tbilisi",
     "wof:parent_id":85633163,
     "wof:placetype":"region",

--- a/data/110/880/594/7/1108805947.geojson
+++ b/data/110/880/594/7/1108805947.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.312949,
-    "geom:area_square_m":2891717036.014752,
+    "geom:area_square_m":2891716543.093098,
     "geom:bbox":"41.53788,41.431664,42.602123,41.899086",
     "geom:latitude":41.644803,
     "geom:longitude":42.087337,
@@ -407,12 +407,14 @@
         "gn:id":615929,
         "gp:id":20070400,
         "hasc:id":"GE.AJ",
+        "iso:code":"GE-AJ",
         "iso:id":"GE-AJ",
         "wd:id":"Q45693"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"GE",
     "wof:created":1485972932,
-    "wof:geomhash":"4d9a67ea4f5e664579a841aa013ffa6b",
+    "wof:geomhash":"31121228b804bc2f46c08d7fe3bcf97e",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -429,7 +431,7 @@
         "abk",
         "oss"
     ],
-    "wof:lastmodified":1690921386,
+    "wof:lastmodified":1695884326,
     "wof:name":"Ajara Autonomous Republic",
     "wof:parent_id":85633163,
     "wof:placetype":"region",

--- a/data/110/880/595/1/1108805951.geojson
+++ b/data/110/880/595/1/1108805951.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.678884,
-    "geom:area_square_m":6288061563.227267,
+    "geom:area_square_m":6288061563.22713,
     "geom:bbox":"43.6721382141,41.1641693115,45.3153190613,41.8561897278",
     "geom:latitude":41.490216,
     "geom:longitude":44.491076,
@@ -23,7 +23,7 @@
     "lbl:longitude":44.424772,
     "lbl:min_zoom":8.0,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:max_zoom":11.0,
     "mz:min_zoom":7.7,
     "name:abk_x_preferred":[
@@ -194,11 +194,13 @@
     "wof:concordances":{
         "fips:code":"GG68",
         "hasc:id":"GE.KK",
+        "iso:code":"GE-KK",
         "iso:id":"GE-KK"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"GE",
     "wof:created":1485972932,
-    "wof:geomhash":"edf9554d5d008767c62ed765ec0ef9f4",
+    "wof:geomhash":"4908b6c82366190d10adf7d4bd5631e7",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -215,7 +217,7 @@
         "abk",
         "oss"
     ],
-    "wof:lastmodified":1566637093,
+    "wof:lastmodified":1695880874,
     "wof:name":"Kvemo Kartli",
     "wof:parent_id":85633163,
     "wof:placetype":"region",

--- a/data/110/880/595/1/1108805951.geojson
+++ b/data/110/880/595/1/1108805951.geojson
@@ -217,7 +217,7 @@
         "abk",
         "oss"
     ],
-    "wof:lastmodified":1695880874,
+    "wof:lastmodified":1695884281,
     "wof:name":"Kvemo Kartli",
     "wof:parent_id":85633163,
     "wof:placetype":"region",

--- a/data/110/880/595/3/1108805953.geojson
+++ b/data/110/880/595/3/1108805953.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.694411,
-    "geom:area_square_m":6427031594.602209,
+    "geom:area_square_m":6427032608.635651,
     "geom:bbox":"42.493076,41.10561,43.966663,41.939102",
     "geom:latitude":41.538851,
     "geom:longitude":43.329346,
@@ -23,7 +23,7 @@
     "lbl:longitude":43.318059,
     "lbl:min_zoom":8.0,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:max_zoom":11.0,
     "mz:min_zoom":7.7,
     "name:eng_x_preferred":[
@@ -59,11 +59,13 @@
     "wof:concordances":{
         "fips:code":"GG72",
         "hasc:id":"GE.SJ",
+        "iso:code":"GE-SJ",
         "iso:id":"GE-SJ"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"GE",
     "wof:created":1485972932,
-    "wof:geomhash":"542383d269a89cf8df202ee5aa34c1a1",
+    "wof:geomhash":"6ec6ec007a236131e53ccf82e5de1946",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -80,7 +82,7 @@
         "abk",
         "oss"
     ],
-    "wof:lastmodified":1627522152,
+    "wof:lastmodified":1695884282,
     "wof:name":"Samtskhe-Javakheti",
     "wof:parent_id":85633163,
     "wof:placetype":"region",

--- a/data/110/880/595/5/1108805955.geojson
+++ b/data/110/880/595/5/1108805955.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.226777,
-    "geom:area_square_m":2084964931.305123,
+    "geom:area_square_m":2084964931.305003,
     "geom:bbox":"41.711643219,41.7796287537,42.6688728333,42.1848144531",
     "geom:latitude":41.96691,
     "geom:longitude":42.153935,
@@ -23,7 +23,7 @@
     "lbl:longitude":42.081518,
     "lbl:min_zoom":8.0,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:max_zoom":11.0,
     "mz:min_zoom":7.7,
     "name:abk_x_preferred":[
@@ -200,11 +200,13 @@
     "wof:concordances":{
         "fips:code":"GG65",
         "hasc:id":"GE.GU",
+        "iso:code":"GE-GU",
         "iso:id":"GE-GU"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"GE",
     "wof:created":1485972932,
-    "wof:geomhash":"c6e28327516fe55924695d4e7dc27bea",
+    "wof:geomhash":"62ce9dc866a17ecf1609de0ad3413f73",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -221,7 +223,7 @@
         "abk",
         "oss"
     ],
-    "wof:lastmodified":1566637094,
+    "wof:lastmodified":1695884281,
     "wof:name":"Guria",
     "wof:parent_id":85633163,
     "wof:placetype":"region",

--- a/data/110/880/595/7/1108805957.geojson
+++ b/data/110/880/595/7/1108805957.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.962506,
-    "geom:area_square_m":8689089873.250132,
+    "geom:area_square_m":8689090132.774261,
     "geom:bbox":"40.002357,42.41777,42.154465,43.584003",
     "geom:latitude":43.106368,
     "geom:longitude":41.16288,
@@ -23,7 +23,7 @@
     "lbl:longitude":41.3257,
     "lbl:min_zoom":8.0,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:max_zoom":11.0,
     "mz:min_zoom":7.7,
     "name:eng_x_preferred":[
@@ -59,11 +59,13 @@
     "wof:concordances":{
         "fips:code":"GG02",
         "hasc:id":"GE.AB",
+        "iso:code":"GE-AB",
         "iso:id":"GE-AB"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"GE",
     "wof:created":1485972933,
-    "wof:geomhash":"c484f231b65480adde521d5d0cd4394b",
+    "wof:geomhash":"a625764ea4d82faeea3967f9e9c1ba13",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -80,7 +82,7 @@
         "abk",
         "oss"
     ],
-    "wof:lastmodified":1627522152,
+    "wof:lastmodified":1695884283,
     "wof:name":"Abkhazeti Autonomous Republic",
     "wof:parent_id":85633163,
     "wof:placetype":"region",

--- a/data/110/880/595/9/1108805959.geojson
+++ b/data/110/880/595/9/1108805959.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.556813,
-    "geom:area_square_m":5062334659.828671,
+    "geom:area_square_m":5062336039.822453,
     "geom:bbox":"42.35825,42.362499,43.950596,42.965092",
     "geom:latitude":42.670733,
     "geom:longitude":43.138405,
@@ -23,7 +23,7 @@
     "lbl:longitude":43.192697,
     "lbl:min_zoom":8.0,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:max_zoom":11.0,
     "mz:min_zoom":7.7,
     "name:eng_x_preferred":[
@@ -59,11 +59,13 @@
     "wof:concordances":{
         "fips:code":"GG70",
         "hasc:id":"GE.RK",
+        "iso:code":"GE-RL",
         "iso:id":"GE-RL"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"GE",
     "wof:created":1485972933,
-    "wof:geomhash":"393136e8f26cd7d936c630add790aa36",
+    "wof:geomhash":"07f8ac6f608954c9a7154fb75cf049af",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -80,7 +82,7 @@
         "abk",
         "oss"
     ],
-    "wof:lastmodified":1627522152,
+    "wof:lastmodified":1695884283,
     "wof:name":"Racha-Leckhumi-Kvemo Svaneti",
     "wof:parent_id":85633163,
     "wof:placetype":"region",

--- a/data/856/331/63/85633163.geojson
+++ b/data/856/331/63/85633163.geojson
@@ -1396,6 +1396,7 @@
         "hasc:id":"GE",
         "icao:code":"4l",
         "ioc:id":"GEO",
+        "iso:code":"GE",
         "itu:id":"GEO",
         "loc:id":"n81055241",
         "m49:code":"268",
@@ -1408,6 +1409,7 @@
         "wk:page":"Georgia (country)",
         "wmo:id":"GG"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"GE",
     "wof:country_alpha3":"GEO",
     "wof:geom_alt":[
@@ -1432,7 +1434,7 @@
         "abk",
         "oss"
     ],
-    "wof:lastmodified":1694639631,
+    "wof:lastmodified":1695881293,
     "wof:name":"Georgia",
     "wof:parent_id":102191569,
     "wof:placetype":"country",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.